### PR TITLE
 manifest: Update to BaseApp 24.04 and Runtime 46beta 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ To know more refer https://github.com/sugarlabs/colordeducto
 ```
 git clone https://github.com/flathub/org.sugarlabs.ColorDeducto.git
 cd org.sugarlabs.ColorDeducto
-flatpak -y --user install org.gnome.{Platform,Sdk}//44
+flatpak -y --user install flathub org.gnome.{Platform,Sdk}//46
+flatpak -y --user install org.sugarlabs.BaseApp//24.04
 flatpak-builder --user --force-clean --install build org.sugarlabs.ColorDeducto.json
 ```
 

--- a/colordeducto-info.patch
+++ b/colordeducto-info.patch
@@ -1,8 +1,8 @@
 diff --git a/activity/activity.info b/activity/activity.info
-index ef61148..bbf6496 100644
+index ef61148..dd49b84 100644
 --- a/activity/activity.info
 +++ b/activity/activity.info
-@@ -1,10 +1,19 @@
+@@ -1,10 +1,20 @@
  [Activity]
  name = ColorDeducto
  exec = sugar-activity3 ColorDeductoActivity.ColorDeductoActivity
@@ -15,15 +15,16 @@ index ef61148..bbf6496 100644
 -license = GPLv3
 -summary = a game based on logical induction
 -category = game
-+release_date = 2020-03-07
-+metadata_license = CC0-1.0
 +license = GPLv3+
 +summary = A game based on logical induction
++category = Game
++release_date = 2020-03-07
++metadata_license = CC0-1.0
 +description = Color Deducto is a learning activity to help children learn the art of inductive logic through pattern recognition.
 +repository = https://github.com/sugarlabs/colordeducto
 +url = https://github.com/sugarlabs/colordeducto
-+category = Game
 +tags = Game
 +update_contact = tch@sugarlabs.org
 +developer_name = Sugar Labs Community
++developer_id = org.sugarlabs
 +screenshots = https://i.imgur.com/jUFQPTx.png

--- a/org.sugarlabs.ColorDeducto.json
+++ b/org.sugarlabs.ColorDeducto.json
@@ -1,9 +1,9 @@
 {
     "app-id": "org.sugarlabs.ColorDeducto",
     "base": "org.sugarlabs.BaseApp",
-    "base-version": "23.06",
+    "base-version": "24.04",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "separate-locales": false,
     "command": "sugarapp",

--- a/org.sugarlabs.ColorDeducto.json
+++ b/org.sugarlabs.ColorDeducto.json
@@ -26,6 +26,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/sugarlabs/colordeducto",
+                    "tag": "v8",
                     "commit": "008ec27c5e2a3dce967347571ca3bb022cd97af7",
                     "x-checker-data": {
                         "type": "git",


### PR DESCRIPTION
updated manifest and README file
External data checker was showing that there is an update even though the module was already on latest version.
This was caused due to missing of version tag. This has been fixed by adding a tag in the module.